### PR TITLE
Fix: Updates to work with Gnome 40.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -134,7 +134,7 @@ const WebSearchProvider = new Lang.Class({
   activateResult: function (identifier, terms) {
     // // 'terms' is not the same as what was typed, so 'terms' is not used.
     // let query = terms.join(' ');
-    let query = Main.overview._searchEntry.text;
+    let query = Main.overview.searchEntry.text;
     let queryUrlTemplate = this._searchEngines[identifier].urlTemplate;
     let queryUrl = queryUrlTemplate.replace(
         /{searchTerms}/g, encodeURIComponent(query));


### PR DESCRIPTION
`_searchEntry` has been changed to `searchEntry` since Gnome 40. Updating this fixes the extension on Ubuntu 20.04.